### PR TITLE
feat: update packages and enable multi-framework MTP testing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,9 +11,12 @@ on:
 permissions: write-all
 jobs:
   build:
-    uses: LayeredCraft/devops-templates/.github/workflows/package-build.yaml@v5.0
+    uses: LayeredCraft/devops-templates/.github/workflows/package-build.yaml@feature/multi-framework-mtp-support
     with:
       dotnet-version: |
         8.0.x
         9.0.x
+      hasTests: true
+      useMtpRunner: true
+      testDirectory: "tests"
     secrets: inherit

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -7,7 +7,7 @@ on:
 permissions: write-all
 jobs:
   build:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v5.0
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@feature/multi-framework-mtp-support
     with:
       solution: AWSSecretsManager.sln
       hasTests: true
@@ -15,4 +15,6 @@ jobs:
         8.0.x
         9.0.x
       runCdk: false
+      useMtpRunner: true
+      testDirectory: "tests"
     secrets: inherit

--- a/src/AWSSecretsManager.Provider/AWSSecretsManager.Provider.csproj
+++ b/src/AWSSecretsManager.Provider/AWSSecretsManager.Provider.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecretsManager" Version="4.0.0.13" />
+    <PackageReference Include="AWSSDK.SecretsManager" Version="4.0.0.15" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
     <PackageReference Include="System.Text.Json" Version="9.0.7" />

--- a/tests/AWSSecretsManager.Provider.Tests/AWSSecretsManager.Provider.Tests.csproj
+++ b/tests/AWSSecretsManager.Provider.Tests/AWSSecretsManager.Provider.Tests.csproj
@@ -3,7 +3,12 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <LangVersion>default</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,13 +16,13 @@
     <PackageReference Include="AutoFixture.Xunit3" Version="4.19.0" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="xunit.v3" Version="2.0.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.v3" Version="3.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="AwesomeAssertions" Version="9.0.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AWSSecretsManager.Provider.Tests/Internal/SecretsManagerConfigurationProviderTests.cs
+++ b/tests/AWSSecretsManager.Provider.Tests/Internal/SecretsManagerConfigurationProviderTests.cs
@@ -160,7 +160,7 @@ public class SecretsManagerConfigurationProviderTests
         const string secretKey = "KEY";
         var firstSecretArn = listSecretsResponse.SecretList.Select(x => x.ARN).First();
         secretsManager.GetSecretValueAsync(Arg.Is<GetSecretValueRequest>(x => x.SecretId.Equals(firstSecretArn)),
-                Arg.Any<CancellationToken>()).Returns(Task.FromResult(getSecretValueResponse));
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(getSecretValueResponse));
 
         options.SecretFilter = _ => true;
         options.AcceptedSecretArns = new List<string> { firstSecretArn };
@@ -170,7 +170,7 @@ public class SecretsManagerConfigurationProviderTests
 
         secretsManager.DidNotReceive()
             .GetSecretValueAsync(Arg.Is<GetSecretValueRequest>(x => !x.SecretId.Equals(firstSecretArn)),
-                    Arg.Any<CancellationToken>());
+                Arg.Any<CancellationToken>());
         secretsManager.DidNotReceive().ListSecretsAsync(Arg.Any<ListSecretsRequest>(), Arg.Any<CancellationToken>());
 
         sut.Get(testEntry.Name).Should().BeNull();
@@ -183,8 +183,8 @@ public class SecretsManagerConfigurationProviderTests
         [Frozen] SecretsManagerConfigurationProviderOptions options, SecretsManagerConfigurationProvider sut)
     {
         secretsManager.GetSecretValueAsync(
-                Arg.Is<GetSecretValueRequest>(x => x.SecretId.Equals(getSecretValueResponse.ARN)),
-                Arg.Any<CancellationToken>()).Returns(Task.FromResult(getSecretValueResponse));
+            Arg.Is<GetSecretValueRequest>(x => x.SecretId.Equals(getSecretValueResponse.ARN)),
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(getSecretValueResponse));
 
         options.AcceptedSecretArns = new List<string> { getSecretValueResponse.ARN };
 
@@ -193,8 +193,8 @@ public class SecretsManagerConfigurationProviderTests
 
         secretsManager.DidNotReceive()
             .GetSecretValueAsync(
-                    Arg.Is<GetSecretValueRequest>(x => !x.SecretId.Equals(getSecretValueResponse.ARN)),
-                    Arg.Any<CancellationToken>());
+                Arg.Is<GetSecretValueRequest>(x => !x.SecretId.Equals(getSecretValueResponse.ARN)),
+                Arg.Any<CancellationToken>());
 
         sut.Get(getSecretValueResponse.Name).Should().Be(getSecretValueResponse.SecretString);
     }
@@ -214,8 +214,8 @@ public class SecretsManagerConfigurationProviderTests
         };
 
         secretsManager.ListSecretsAsync(
-                Arg.Is<ListSecretsRequest>(request => request.Filters == options.ListSecretsFilters),
-                Arg.Any<CancellationToken>()).Returns(Task.FromResult(listSecretsResponse));
+            Arg.Is<ListSecretsRequest>(request => request.Filters == options.ListSecretsFilters),
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(listSecretsResponse));
 
         secretsManager.GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(getSecretValueResponse));
@@ -267,8 +267,8 @@ public class SecretsManagerConfigurationProviderTests
     }
 
     [Theory, CustomAutoData]
-    public void Get_secret_value_request_can_be_customized_via_options([Frozen] SecretListEntry testEntry,
-        ListSecretsResponse listSecretsResponse, GetSecretValueResponse getSecretValueResponse,
+    public void Get_secret_value_request_can_be_customized_via_options(ListSecretsResponse listSecretsResponse,
+        GetSecretValueResponse getSecretValueResponse,
         string secretVersionStage, [Frozen] IAmazonSecretsManager secretsManager,
         [Frozen] SecretsManagerConfigurationProviderOptions options, SecretsManagerConfigurationProvider sut)
     {
@@ -284,12 +284,12 @@ public class SecretsManagerConfigurationProviderTests
 
         secretsManager.Received(1)
             .GetSecretValueAsync(Arg.Is<GetSecretValueRequest>(x => x.VersionStage == secretVersionStage),
-                    Arg.Any<CancellationToken>());
+                Arg.Any<CancellationToken>());
     }
 
     [Theory, CustomAutoData]
-    public void Should_throw_on_missing_secret_value([Frozen] SecretListEntry testEntry,
-        ListSecretsResponse listSecretsResponse, [Frozen] IAmazonSecretsManager secretsManager,
+    public void Should_throw_on_missing_secret_value(ListSecretsResponse listSecretsResponse,
+        [Frozen] IAmazonSecretsManager secretsManager,
         SecretsManagerConfigurationProvider sut)
     {
         secretsManager.ListSecretsAsync(Arg.Any<ListSecretsRequest>(), Arg.Any<CancellationToken>())
@@ -303,8 +303,8 @@ public class SecretsManagerConfigurationProviderTests
     }
 
     [Theory, CustomAutoData]
-    public void Should_skip_on_missing_secret_value_if_configured([Frozen] SecretListEntry testEntry,
-        ListSecretsResponse listSecretsResponse, [Frozen] IAmazonSecretsManager secretsManager,
+    public void Should_skip_on_missing_secret_value_if_configured(ListSecretsResponse listSecretsResponse,
+        [Frozen] IAmazonSecretsManager secretsManager,
         [Frozen] SecretsManagerConfigurationProviderOptions options, SecretsManagerConfigurationProvider sut)
     {
         secretsManager.ListSecretsAsync(Arg.Any<ListSecretsRequest>(), Arg.Any<CancellationToken>())
@@ -320,8 +320,8 @@ public class SecretsManagerConfigurationProviderTests
     }
 
     [Theory, CustomAutoData]
-    public void Should_throw_on_batch_missing_secret_values([Frozen] SecretListEntry testEntry,
-        ListSecretsResponse listSecretsResponse, [Frozen] IAmazonSecretsManager secretsManager,
+    public void Should_throw_on_batch_missing_secret_values(ListSecretsResponse listSecretsResponse,
+        [Frozen] IAmazonSecretsManager secretsManager,
         [Frozen] SecretsManagerConfigurationProviderOptions options, SecretsManagerConfigurationProvider sut,
         IFixture fixture)
     {
@@ -336,7 +336,7 @@ public class SecretsManagerConfigurationProviderTests
             .Create();
 
         secretsManager.BatchGetSecretValueAsync(Arg.Any<BatchGetSecretValueRequest>(),
-                Arg.Any<CancellationToken>()).Returns(Task.FromResult(batchGetSecretValueResponse));
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(batchGetSecretValueResponse));
 
         options.UseBatchFetch = true;
 
@@ -345,8 +345,8 @@ public class SecretsManagerConfigurationProviderTests
     }
 
     [Theory, CustomAutoData]
-    public void Should_skip_on_missing_batch_secret_values_if_configured([Frozen] SecretListEntry testEntry,
-        ListSecretsResponse listSecretsResponse, [Frozen] IAmazonSecretsManager secretsManager,
+    public void Should_skip_on_missing_batch_secret_values_if_configured(ListSecretsResponse listSecretsResponse,
+        [Frozen] IAmazonSecretsManager secretsManager,
         [Frozen] SecretsManagerConfigurationProviderOptions options, SecretsManagerConfigurationProvider sut,
         IFixture fixture)
     {
@@ -361,7 +361,7 @@ public class SecretsManagerConfigurationProviderTests
             .Create();
 
         secretsManager.BatchGetSecretValueAsync(Arg.Any<BatchGetSecretValueRequest>(),
-                Arg.Any<CancellationToken>()).Returns(Task.FromResult(batchGetSecretValueResponse));
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(batchGetSecretValueResponse));
 
         options.UseBatchFetch = true;
         options.IgnoreMissingValues = true;
@@ -400,7 +400,7 @@ public class SecretsManagerConfigurationProviderTests
     public async Task Should_reload_when_forceReload_called([Frozen] SecretListEntry testEntry,
         ListSecretsResponse listSecretsResponse, GetSecretValueResponse getSecretValueInitialResponse,
         GetSecretValueResponse getSecretValueUpdatedResponse, [Frozen] IAmazonSecretsManager secretsManager,
-        [Frozen] SecretsManagerConfigurationProviderOptions options, SecretsManagerConfigurationProvider sut,
+        SecretsManagerConfigurationProvider sut,
         Action<object> changeCallback, object changeCallbackState)
     {
         secretsManager.ListSecretsAsync(Arg.Any<ListSecretsRequest>(), Arg.Any<CancellationToken>())


### PR DESCRIPTION
## Summary
- Update all package references to latest versions
- Point workflows to new devops-templates branch with multi-framework MTP support
- Enable proper testing for both .NET 8 and .NET 9 using Microsoft Testing Platform

## Changes
- Updated workflow references to use `feature/multi-framework-mtp-support` branch
- This enables testing each framework individually with `dotnet run --framework net8.0/net9.0`
- Maintains compatibility with both MSTest and MTP runners

## Test plan
- [x] Verify workflows can discover MTP test projects
- [x] Confirm tests run for both net8.0 and net9.0 frameworks
- [x] Validate coverage collection works across frameworks (if enabled)

🤖 Generated with [Claude Code](https://claude.ai/code)