### PR TITLE
feat: add Native AOT support

### DIFF
--- a/.agents/skills/dotnet-aot-library-validation/SKILL.md
+++ b/.agents/skills/dotnet-aot-library-validation/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: dotnet-aot-library-validation
+description: >-
+  Makes .NET class libraries Native AOT compatible: enables AOT/trim analyzers,
+  fixes IL2xxx/IL3xxx warnings, replaces reflection with source generators, and
+  validates with an AOT-published test app in CI. Use when the user wants to add
+  AOT support or trim compatibility to a .NET library, mentions IsAotCompatible,
+  PublishAot, or Native AOT for a NuGet/class library, asks about trim or AOT
+  warnings (IL2026, IL2067, IL2070, IL2104, IL2125, IL3050, IL3051, IL3058),
+  RequiresUnreferencedCode, RequiresDynamicCode, DynamicallyAccessedMembers,
+  MakeGenericType or Activator.CreateInstance failures under AOT, System.Text.Json
+  source generation, LibraryImport vs DllImport, or CI validation of AOT
+  compatibility. Library-authoring focused; not for publishing end-user apps.
+---
+
+# .NET library AOT compatibility
+
+Native AOT compiles IL to native code at publish time. There is no JIT at runtime,
+so nothing can be generated or discovered dynamically that was not known at build
+time. Trim analysis enforces this: the AOT compiler must trim, and reflection-based
+patterns break.
+
+The guiding principle from the .NET team: **if an app publishes for AOT with zero
+warnings, it will behave the same after AOT as without.** Warnings mean the tooling
+cannot guarantee correctness. A library that publishes clean against a
+`TrimmerRootAssembly`-rooted test app is trustworthy for AOT consumers.
+
+Scope: class libraries meant to be _consumed by_ AOT apps. This is not about
+publishing an app itself, nor about publishing a library _as_ a native library
+(`[UnmanagedCallersOnly]` — a different, unrelated scenario).
+
+## Workflow
+
+Work through these phases in order. Fixes at earlier phases reduce work in later
+ones. Always fix dependencies before dependents (bottom-up) — annotations added
+low in the stack surface warnings in higher layers, and a library cannot be
+verified while a dependency still warns.
+
+### 1. Assess the project
+
+Read the library's .csproj and scan the source. Record:
+
+- `TargetFrameworks` (analyzers need `net7.0`+ annotations; `net8.0` recommended for the fullest set — multi-target if needed)
+- Existing `IsAotCompatible` / `IsTrimmable` / `EnableAotAnalyzer` properties
+- Dependencies (`PackageReference`) — an un-annotated dependency caps what this
+  library can achieve; the OpenTelemetry SqlClient case: when the underlying
+  library is not AOT compatible, the wrapper gets `[RequiresUnreferencedCode]`
+- Reflection usage: `GetType()`, `GetMembers`, `Activator.CreateInstance`,
+  `MakeGenericType`, `Assembly.Load*`, `Type.GetType`
+- Serialization: reflection-based (`Newtonsoft.Json`, `JsonSerializer` without
+  context, `XmlSerializer`, `BinaryFormatter`)
+- Interop: `[DllImport]` (runtime IL stubs are JIT-generated — blocked under AOT)
+- `System.Linq.Expressions` `.Compile()` usage, `Reflection.Emit`, regex parsing
+
+### 2. Enable analyzers
+
+The `IsAotCompatible` property enables `IsTrimmable`, `EnableTrimAnalyzer`,
+`EnableSingleFileAnalyzer`, and `EnableAotAnalyzer` in one shot:
+
+```xml
+<PropertyGroup>
+  <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+  <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
+</PropertyGroup>
+```
+
+The `Condition` is required when the library multi-targets older frameworks —
+the analyzers depend on annotations that only exist in the `net7.0`+ reference
+assemblies (and `RequiresDynamicCode` in `net7.0`; prefer `net8.0` for the
+fullest annotations).
+
+Optional, opt-in dependency verification (noisy, but catches un-annotated deps):
+
+```xml
+<VerifyReferenceAotCompatibility>true</VerifyReferenceAotCompatibility> <!-- IL3058 -->
+<VerifyReferenceTrimCompatibility>true</VerifyReferenceTrimCompatibility> <!-- IL2125 -->
+```
+
+Build and collect the full warning list (`dotnet build` for the net8.0+ TFM).
+Map each warning with `references/warning-catalog.md`.
+
+### 3. Fix warnings, in this order of preference
+
+1. **Eliminate** the dynamic code. Often reflection exists only for an
+   optimization or a workaround; a public API on the dependency or a modern
+   framework API replaces it outright.
+2. **Annotate** so the tooling can see what reflection will touch. Attributes
+   flow bottom-up through the call graph: `[DynamicallyAccessedMembers]`,
+   `[RequiresUnreferencedCode]`, `[RequiresDynamicCode]`. Propagate until
+   warnings land only on deliberately-incompatible _public_ APIs.
+3. **Redesign the API** for AOT: source-generated serialization, `JsonTypeInfo<T>`
+   overloads, `[LibraryImport]`, generated regex. See
+   `references/source-gen-recipes.md`.
+4. **Suppress** with `[UnconditionalSuppressMessage]` only as a last resort, only
+   with proof that the reflected members are visible targets of reflection
+   elsewhere, and only with a runtime test in the AOT-published test app.
+   Suppressing because "the app only passes types the app uses" is invalid —
+   such members get inlined, renamed, or removed. See `references/common-fixes.md`.
+
+Concrete before/after recipes for the highest-frequency patterns live in
+`references/common-fixes.md`. Anti-patterns to avoid: annotating virtual or
+interface methods (every override must match), reflection inside static
+constructors (warning spreads to the whole class).
+
+### 4. Validate with an AOT-published test app
+
+Roslyn analyzers see one project at a time; they cannot analyze dependency
+implementations, so they can miss warnings. The AOT compiler can. The complete
+validation loop is:
+
+- A console test app with `PublishAot` referencing the library
+- `TrimmerRootAssembly` to force analysis of every library member
+- A publish script that fails on any warning, plus a CI workflow
+
+Scaffold and wiring details: `references/test-app-validation.md`. If the fix
+phase introduced any suppression, the test app _must also execute_ library code
+paths (the OpenTelemetry pattern) — static analysis is blind to suppressed
+warnings by definition.
+
+### 5. Legacy TFM support (only if multi-targeting below net5.0)
+
+Trim/AOT attributes do not exist before `net5.0` (`net7.0` for
+`RequiresDynamicCode`). Options: `#if` directives, internal attribute
+definitions, or PolySharp. Trade-offs matter; see `references/legacy-tfms.md`.
+
+### 6. Ship
+
+Keep `IsAotCompatible` set in the shipped package. Note for consumers: the
+`IsAotCompatible` _assembly metadata_ consumed by `VerifyReferenceAotCompatibility`
+(IL3058) is only written by .NET 10+ builds, so older annotated packages still
+trigger IL3058 — that check is opt-in for a reason.
+
+## Key principles
+
+- Zero warnings is the goal; each warning is a possible runtime break in a
+  consumer's AOT app, even if it happens to work today.
+- Annotate the lowest layers first; re-run after each dependency fix.
+- `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]` on a public API is a
+  _communication mechanism_, not a failure — it moves the warning to the caller
+  who chose the incompatible path, mirroring how `System.Text.Json` shipped.
+- Introducing new trim/AOT warnings is a breaking change for
+  `PublishTrimmed`/`PublishAot` consumers — CI validation belongs on every PR.
+
+## Reference files
+
+| File                                | When to read                                                       |
+| ----------------------------------- | ------------------------------------------------------------------ |
+| `references/warning-catalog.md`     | Mapping build output to meaning + typical fix                      |
+| `references/common-fixes.md`        | Before/after recipes for recurring patterns                        |
+| `references/source-gen-recipes.md`  | Serialization, interop, regex, options/config replacement patterns |
+| `references/test-app-validation.md` | Test app csproj, publish script, CI workflow                       |
+| `references/legacy-tfms.md`         | Multi-targeting below net5.0 without losing annotations            |

--- a/.agents/skills/dotnet-aot-library-validation/evals/evals.json
+++ b/.agents/skills/dotnet-aot-library-validation/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill_name": "dotnet-aot-library-validation",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We're about to ship MyLib.Core as a NuGet package and want to advertise it as AOT compatible. When I set IsAotCompatible the build lights up with a bunch of IL2xxx and IL3xxx warnings (IL2070, IL2067, IL3050, and friends). Please make the library AOT compatible and set up something so regressions get caught in CI on every PR. The library lives in evals/fixtures/mylib/src/MyLib.Core (project fixture for this task; treat it as the repo).",
+      "expected_output": "Library csproj updated with conditional IsAotCompatible for net8.0+, offending reflection patterns fixed or annotated (PluginLoader annotation flow, GenericCache MakeGenericType restriction, Enum.GetValues<TEnum>, JSON source-gen context replacing reflection serialization, DllImport converted to LibraryImport), AOT test app scaffolded with PublishAot + TrimmerRootAssembly, publish-check script and CI workflow added, build compiles without new warnings.",
+      "files": [
+        "evals/fixtures/mylib/src/MyLib.Core/MyLib.Core.csproj",
+        "evals/fixtures/mylib/src/MyLib.Core/PluginLoader.cs",
+        "evals/fixtures/mylib/src/MyLib.Core/GenericCache.cs",
+        "evals/fixtures/mylib/src/MyLib.Core/Payload.cs",
+        "evals/fixtures/mylib/src/MyLib.Core/Native.cs"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "dotnet build on my library fails the AOT analysis with 'warning IL3050: Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling' in GenericCache.RegisterSlot. Explain why this breaks under Native AOT and fix it in the fixture at evals/fixtures/mylib/src/MyLib.Core/GenericCache.cs.",
+      "expected_output": "Explanation: AOT pre-generates native code per generic instantiation; unknown instantiations (especially value-type args) don't exist at runtime. Fix restricts MakeGenericType to statically known types (hardcoded instantiation map or overloads) instead of suppressing.",
+      "files": ["evals/fixtures/mylib/src/MyLib.Core/GenericCache.cs"]
+    },
+    {
+      "id": 3,
+      "prompt": "My team maintains a .NET library that other companies consume from ASP.NET Core apps they publish with PublishAot. The library uses Newtonsoft.Json for payload parsing, DllImport for two native calls, and scans types with reflection at startup. What's the plan to make it AOT compatible? We target netstandard2.0 and net8.0. Don't change any code yet — I want the plan and gotchas first.",
+      "expected_output": "Structured plan: enable IsAotCompatible analyzers, replace Newtonsoft with System.Text.Json source generation, convert DllImport to LibraryImport, annotate/propagate reflection usage, bottom-up dependency-first ordering, netstandard2.0 legacy-TFM attribute strategy (internal attribute defs or PolySharp), AOT test app + CI validation, warning-catalog reading for IL2xxx/IL3xxx.",
+      "files": []
+    }
+  ]
+}

--- a/.agents/skills/dotnet-aot-library-validation/evals/fixtures/mylib/src/MyLib.Core/GenericCache.cs
+++ b/.agents/skills/dotnet-aot-library-validation/evals/fixtures/mylib/src/MyLib.Core/GenericCache.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+namespace MyLib.Core;
+
+/// <summary>Caches values keyed by a runtime-provided type.</summary>
+public static class GenericCache
+{
+    private static readonly Dictionary<Type, object> Slots = new();
+
+    public static void RegisterSlot<T>(Type valueType)
+    {
+        var slotType = typeof(ContextSlot<>).MakeGenericType(valueType);
+        var slot = Activator.CreateInstance(slotType, typeof(T))!;
+        Slots[slotType] = slot;
+    }
+}
+
+public class ContextSlot<T>
+{
+    public Type Bound { get; }
+    public ContextSlot(Type bound) => Bound = bound;
+}

--- a/.agents/skills/dotnet-aot-library-validation/evals/fixtures/mylib/src/MyLib.Core/MyLib.Core.csproj
+++ b/.agents/skills/dotnet-aot-library-validation/evals/fixtures/mylib/src/MyLib.Core/MyLib.Core.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+  </ItemGroup>
+
+</Project>

--- a/.agents/skills/dotnet-aot-library-validation/evals/fixtures/mylib/src/MyLib.Core/Native.cs
+++ b/.agents/skills/dotnet-aot-library-validation/evals/fixtures/mylib/src/MyLib.Core/Native.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace MyLib.Core;
+
+public static partial class Native
+{
+    [DllImport("nativelib", EntryPoint = "mylib_now", CharSet = CharSet.Unicode)]
+    internal static extern long Now(string label);
+
+    [DllImport("nativelib", EntryPoint = "mylib_compress")]
+    internal static extern byte[] Compress(byte[] input);
+}

--- a/.agents/skills/dotnet-aot-library-validation/evals/fixtures/mylib/src/MyLib.Core/Payload.cs
+++ b/.agents/skills/dotnet-aot-library-validation/evals/fixtures/mylib/src/MyLib.Core/Payload.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Text.Json;
+
+namespace MyLib.Core;
+
+/// <summary>Payload helpers used by exporters.</summary>
+public static class Payload
+{
+    public static string ToJson(object value) =>
+        JsonSerializer.Serialize(value, value.GetType());
+
+    public static T FromJson<T>(string json) where T : new() =>
+        JsonSerializer.Deserialize<T>(json) ?? new T();
+
+    public static string DescribeKind(RecordKind kind)
+    {
+        var names = Enum.GetValues(typeof(RecordKind));
+        var best = kind.ToString();
+        foreach (var name in names) if (name.ToString() == best) return best;
+        return "Unknown";
+    }
+}
+
+public enum RecordKind
+{
+    Trace,
+    Span,
+    Metric
+}

--- a/.agents/skills/dotnet-aot-library-validation/evals/fixtures/mylib/src/MyLib.Core/PluginLoader.cs
+++ b/.agents/skills/dotnet-aot-library-validation/evals/fixtures/mylib/src/MyLib.Core/PluginLoader.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace MyLib.Core;
+
+/// <summary>Discovers and instantiates plugin types via reflection.</summary>
+public static class PluginLoader
+{
+    public static IEnumerable<IPlugin> LoadPlugins(Assembly assembly, Type markerType)
+    {
+        var results = new List<IPlugin>();
+        foreach (var type in assembly.GetTypes())
+        {
+            if (!markerType.IsAssignableFrom(type) || type.IsAbstract)
+            {
+                continue;
+            }
+
+            foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance))
+            {
+                // inspect plugin surface
+                _ = method.GetParameters();
+            }
+
+            results.Add((IPlugin)Activator.CreateInstance(type)!);
+        }
+        return results;
+    }
+}
+
+public interface IPlugin
+{
+    string Name { get; }
+    void Execute();
+}

--- a/.agents/skills/dotnet-aot-library-validation/references/common-fixes.md
+++ b/.agents/skills/dotnet-aot-library-validation/references/common-fixes.md
@@ -1,0 +1,170 @@
+# Common fixes
+
+Before/after recipes for the patterns that produce most trim/AOT warnings in
+libraries. Order of preference: eliminate > annotate > redesign > suppress.
+Source: Microsoft Learn trimming docs + "How to make libraries compatible with
+native AOT" (Eric Erhardt, devblogs.microsoft.com/dotnet/creating-aot-compatible-libraries/).
+
+## 1. Attribute flow (annotate)
+
+Warnings say the _source_ of a value doesn't match the _target's_ requirement.
+Add matching annotations at the source; propagate up the call graph until either
+a statically known type flows in or the annotation reaches a public API.
+
+```csharp
+// Before: IL2067 — Activator.CreateInstance requires PublicParameterlessConstructor
+public static object CreateNewObject(Type t) => Activator.CreateInstance(t);
+
+// After: requirement stated on the parameter; callers now checked too
+public static object CreateNewObject(
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    Type t) => Activator.CreateInstance(t);
+```
+
+Annotate fields and generic type parameters the same way:
+
+```csharp
+// Field
+[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+static Type type;
+
+// Generic parameter
+static void Use<T>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TParameters p) { }
+```
+
+Rules of thumb:
+
+- Start at the lowest layer; expect new warnings to surface in higher layers
+  afterwards — that is the flow being made visible, not a regression.
+- Do not annotate virtual or interface methods — every override must carry a
+  matching annotation (IL2046/IL3051). Prefer annotating concrete entry points.
+- Never put analyzable-on-reflection code in static constructors; the warning
+  propagates to every member of the class.
+- Once annotations reach public APIs only, consumer code gets warnings solely
+  when _it_ calls incompatible members — and IL2104 rollups disappear.
+
+## 2. `MakeGenericType` / `MakeGenericMethod` (IL3050)
+
+The AOT compiler pre-generates code per generic instantiation. Unknown
+instantiations — especially value-type arguments — are unavailable at runtime.
+
+**Restrict to known types** (OpenTelemetry `RegisterSlot` fix):
+
+```csharp
+// Before: open generic filled at runtime
+var slotType = typeof(ContextSlot<>).MakeGenericType(valueType);
+
+// After: hard-code the instantiations consumers actually use
+static readonly Dictionary<Type, Type> Known = new()
+{
+    [typeof(long)] = typeof(ContextSlot<long>),
+    [typeof(double)] = typeof(ContextSlot<double>),
+    [typeof(int)] = typeof(ContextSlot<int>),
+};
+```
+
+**Reference-type-only trick**: closed generics over _reference_ types share one
+native body, so `MakeGenericType` over class arguments is safe even if
+individually unknown — guard with a generic constraint (`where T : class`) so a
+struct can never reach it.
+
+**Bridge reflection at a known type**: `Type.GetType` with a _constant_ string,
+or `typeof(SomeType)` directly, makes the tooling preserve what reflection
+touches. `Type.GetType(variableString)` cannot be verified.
+
+## 3. `Reflection.Emit` / `DynamicMethod` optimizations
+
+AOT has no JIT. Performance optimizations that emit IL (fast field readers,
+delegate builders) must degrade gracefully:
+
+```csharp
+if (RuntimeFeature.IsDynamicCodeSupported)
+{
+    // JIT path: keep the fast emitted-IL optimization
+    EmitAndCacheGetter();
+}
+else
+{
+    // Native AOT path: plain reflection fallback
+    UseSlowGetter();
+}
+```
+
+Better long-term: remove the need entirely (StackExchange.Redis replaced private
+`MulticastDelegate` field reflection with supported APIs; Pipelines.Sockets.Unofficial
+removed a generic constraint that required reflection bridging, eliminating the
+optimization's need for IL emit in all modes).
+
+## 4. Reflection-based serialization
+
+Reflection serializers cannot work in trimmed apps (walked type graphs get
+trimmed). Replace, don't patch:
+
+- `Newtonsoft.Json` / private forks → `System.Text.Json` source generation
+  (see `references/source-gen-recipes.md`). IdentityModel case study.
+- `JsonSerializer.Serialize(value)` bare calls → pass `JsonTypeInfo<T>` /
+  `JsonSerializerContext` overloads; add source-gen context.
+- APIs taking `object` then calling `.GetType()` (StackExchange.Redis
+  `LuaScript.Prepare` case) → mark `[RequiresUnreferencedCode]` and add a
+  generic sibling that uses `typeof(TParameters)`:
+  `ScriptEvaluate<TParameters>(...)` with
+  `[DynamicallyAccessedMembers(PublicProperties)]`.
+
+`XmlSerializer` and `BinaryFormatter` are not viable under trim/AOT.
+
+## 5. `Enum.GetValues(typeof(T))` and friends
+
+Creating `TEnum[]` at runtime needs generated code for that array type:
+
+```csharp
+// Before (IL3050 in AOT)
+var values = Enum.GetValues(typeof(MyEnum));
+
+// After (.NET 5+, guaranteed generated)
+var values = Enum.GetValues<MyEnum>();
+```
+
+## 6. `System.Linq.Expressions`
+
+`.Compile()` runs interpreted under AOT (correct but slower). Prefer direct
+calls. `Expression.Property(expr, "name")` warns (string-unknown member) — use
+the `PropertyInfo` overload with a statically known `PropertyInfo`. OpenTelemetry
+eventually removed all `Expression` usage; incremental path is static `PropertyInfo`
+first.
+
+## 7. `EventSource.WriteEvent` with object[]
+
+Overloads taking `object[]` are `[RequiresUnreferencedCode]` (payload serialized
+via reflection). Pass 3 or fewer primitive/enum/string args to hit typed
+overloads; .NET 8's new `EventSource` overloads removed most of this
+false-positive class.
+
+## 8. Private reflection against other libraries
+
+Reflection into another library's internals (even "just for speed") breaks when
+the dependency changes shape. Prefer public APIs; often a newer dependency
+version adds the missing member (Google.Protobuf `.Clear()` case). If the
+underlying dependency is itself AOT-incompatible, accept it:
+`[RequiresUnreferencedCode]` the wrapper (OpenTelemetry SqlClient).
+
+## 9. Suppression — last resort
+
+```csharp
+[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2063",
+    Justification = "Only types stored through the annotated setter reach this array.")]
+get => types[i];
+```
+
+- `SuppressMessage` / `#pragma` do not reach publish-time analysis — use
+  `UnconditionalSuppressMessage` only.
+- Valid justification = the reflected members are _visible targets of reflection_
+  (preserved via `[DynamicallyAccessedMembers]`, `DynamicDependency`, or root-keeping
+  code paths) elsewhere.
+- **Invalid** justification: "the app only reflects over types it uses" —
+  non-reflection usage can be inlined, renamed, or removed; Native AOT already
+  optimizes such members away.
+- Every suppression must be covered by a runtime test in the AOT test app
+  (`references/test-app-validation.md`), since the analyzer is silent there by
+  definition.
+- `[DynamicDependency]` only _keeps_ members; it does not express reflection
+  behavior. Combine with suppression, but prefer the other attributes first.

--- a/.agents/skills/dotnet-aot-library-validation/references/legacy-tfms.md
+++ b/.agents/skills/dotnet-aot-library-validation/references/legacy-tfms.md
@@ -1,0 +1,75 @@
+# Legacy TFM support
+
+Trim/AOT attributes did not exist before .NET 5 (`RequiresUnreferencedCode`,
+`DynamicallyAccessedMembers`); `[RequiresDynamicCode]` arrived in .NET 7.
+Libraries still targeting `netstandard2.0` / `net472` hit
+`CS0246: The type or namespace name 'DynamicallyAccessedMembersAttribute' could not be found`.
+
+The .NET team deliberately does **not** ship these attributes as a
+netstandard NuGet package: they are meaningless on .NET Framework, and shipping
+them would imply otherwise (same reasoning as the nullable-annotation attributes).
+
+## Option 1: `#if` directives
+
+```csharp
+public static object CreateNewObject(
+#if NET5_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+    Type t)
+{
+    return Activator.CreateInstance(t);
+}
+```
+
+Drawbacks:
+
+- Readability erodes as annotations accumulate.
+- Missed TFMs are easy — especially with **shared source files** compiled into
+  multiple projects: a project that never targets net5.0+ silently builds the
+  attribute-less variant in _all_ its TFMs. The Roslyn analyzers will not warn
+  about it.
+- Consumers using the netstandard2.0 binary in a .NET 7+ app get warnings from
+  inside the library during publish (no annotations in IL).
+
+## Option 2: Define the attributes internally (recommended for multi-targeting)
+
+The trim/AOT tooling matches these attributes **by fully-qualified name and
+namespace, not by assembly**. A library can define its own copies; the tooling
+respects them identically:
+
+- Keep one shared file (e.g. `TrimAttributes.cs`) containing
+  `[RequiresUnreferencedCode]`, `[DynamicallyAccessedMembers]`,
+  `[RequiresDynamicCode]`, `[UnconditionalSuppressMessage]` in their canonical
+  `System.Diagnostics.CodeAnalysis` namespaces, guarded with
+  `#if !NET5_0_OR_GREATER` (and `#if !NET7_0_OR_GREATER` for
+  `RequiresDynamicCode`) so real BCL types win on modern TFMs.
+- Include the file in every project needing annotations on old TFMs.
+- Reference copy: github.com/eerhardt/blog-resources —
+  `creating-aot-compatible-libraries/TrimmingAttributes.cs`
+
+Advantages: no per-annotation noise, applies on _every_ TFM, one-time setup.
+
+## Option 3: PolySharp
+
+The [PolySharp](https://www.nuget.org/packages/PolySharp/) package generates
+polyfill definitions (including these attributes) at build time as needed —
+same mechanics as Option 2 without maintaining the file yourself.
+
+## Verifying legacy-TFM binaries
+
+Roslyn analyzers still require targeting net7.0+ (they read annotations from
+the reference assemblies). To verify an annotation-complete netstandard2.0
+binary, use the AOT-published test app pattern
+(`references/test-app-validation.md`) — the AOT compiler sees the IL
+annotations regardless of TFM.
+
+## Practical guidance
+
+- Analyzers keep their value: still multi-target `net8.0` (at least) and
+  conditionally set `IsAotCompatible` there, even when also shipping
+  netstandard2.0 with internal attribute copies.
+- Never let the netstandard2.0-only build be what AOT consumers resolve —
+  ship a net8.0+ TFM in the same package so annotated metadata travels with it.
+- Do not pretend netstandard2.0 "supports trimming": trimming itself requires
+  .NET 6+; a trim test app has no benefit against netstandard/net4x targets.

--- a/.agents/skills/dotnet-aot-library-validation/references/source-gen-recipes.md
+++ b/.agents/skills/dotnet-aot-library-validation/references/source-gen-recipes.md
@@ -1,0 +1,129 @@
+# Source generation recipes
+
+Compile-time code generation replaces the runtime codegen that AOT forbids.
+General rule: whenever a library calls an API whose implementation reflects
+over unknown types or emits IL, look for a source-generator-backed variant.
+
+## System.Text.Json source generation
+
+Reflection `JsonSerializer.Serialize/Deserialize<T>` calls are
+`[RequiresUnreferencedCode]` + `[RequiresDynamicCode]`. Create a context:
+
+```csharp
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(WeatherForecast))]
+[JsonSerializable(typeof(List<WeatherForecast>))]   // collections need explicit entries
+internal partial class WeatherForecastContext : JsonSerializerContext { }
+```
+
+Call the context-aware overloads:
+
+```csharp
+json = JsonSerializer.Serialize(value, WeatherForecastContext.Default.WeatherForecast);
+obj  = JsonSerializer.Deserialize(json, WeatherForecastContext.Default.WeatherForecast);
+```
+
+Notes:
+
+- Members declared `object` (and unknown runtime types) need their own
+  `[JsonSerializable(typeof(...))]` entries; unsupported runtime types fail
+  consistently both with and without AOT.
+- Set options via `[JsonSourceGenerationOptions]` so `Context.Default` is
+  preconfigured; or resolve through `JsonSerializerOptions`:
+  `TypeInfoResolver = Context.Default`.
+- Chain multiple contexts with `JsonTypeInfoResolver.Combine(...)` or
+  `options.TypeInfoResolverChain`.
+- Enums as strings: `[JsonConverter(typeof(JsonStringEnumConverter<TEnum>))]` —
+  the non-generic `JsonStringEnumConverter` is **not** supported under AOT.
+  Blanket option: `[JsonSourceGenerationOptions(UseStringEnumConverter = true)]`.
+- App-side hardening: `JsonSerializerIsReflectionEnabledByDefault=false` makes
+  any remaining reflection serialization throw `InvalidOperationException`
+  with a clear message on every runtime, instead of breaking unpredictably
+  under AOT only.
+- Public API design: add `JsonTypeInfo<T>` parameters to public serialize
+  methods so consumers can feed their own contexts.
+
+Docs: learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation
+
+## P/Invoke: `[LibraryImport]` instead of `[DllImport]`
+
+`DllImport` marshalling stubs are IL emitted at runtime — blocked under AOT.
+The .NET 7+ SDK's P/Invoke source generator (on by default) compiles marshalling
+at build time from `[LibraryImport]`:
+
+```csharp
+// Before
+[DllImport("nativelib", EntryPoint = "to_lower", CharSet = CharSet.Unicode)]
+internal static extern string ToLower(string str);
+
+// After
+[LibraryImport("nativelib", EntryPoint = "to_lower", StringMarshalling = StringMarshalling.Utf16)]
+internal static partial string ToLower(string str);   // partial, not extern
+```
+
+Migration deltas:
+
+- `CharSet` → `StringMarshalling` (ANSI removed; UTF-8 first-class: `Utf8`)
+- `CallingConvention` → `[UnmanagedCallConv(CallConvs = new[] { typeof(CallConvStdcall) })]`
+- No equivalents: `BestFitMapping`, `ThrowOnUnmappableChar`, `ExactSpelling`,
+  `PreserveSig` — entry point name is exact; signature translates directly
+- Requires `AllowUnsafeBlocks` for marshalling-generated unsafe code
+- Unsupported `MarshalAs` settings emit compile errors, not runtime surprises
+
+Analyzers (SYSLIB1050–1069) + code fixers automate the conversion.
+
+## Regular expressions: `[GeneratedRegex]`
+
+```csharp
+[GeneratedRegex(@"\d{4}-\d{2}-\d{2}")]
+private static partial Regex DatePattern();
+```
+
+Compile-time generation replaces `new Regex(pattern)` / `Regex.*(pattern)` calls
+that parse patterns at runtime. Not strictly forbidden under AOT, but generated
+regexes are faster everywhere and are the expected library pattern.
+
+## Options validation: `[OptionsValidator]`
+
+Replaces reflection-based validation of option objects with
+`DataAnnotations` attributes:
+
+```csharp
+[OptionsValidator]
+internal sealed partial class HttpStandardResilienceOptionsValidator
+    : IValidateOptions<HttpStandardResilienceOptions> { }
+```
+
+Generator inspects the options type at build time and emits validation code.
+Register in DI. (dotnet/extensions pattern.)
+
+## Configuration binding: `EnableConfigurationBindingGenerator`
+
+```xml
+<PropertyGroup>
+  <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+</PropertyGroup>
+```
+
+Replaces reflection in `ConfigurationBinder` with generated property setters;
+no call-site changes needed. (dotnet/extensions case study.)
+
+## Other useful generators
+
+- YamlDotNet source generator — strongly-typed YAML serialization under AOT
+  (Andrew Lock: andrewlock.net/using-the-yamldotnet-source-generator-for-native-aot/)
+- Dapper.AOT — build-time ADO.NET code generation replacing Dapper's runtime
+  IL emit; also faster at startup in non-AOT apps
+- ASP.NET Core minimal APIs / JSON: `[JsonPropertyName]`-annotated DTOs with
+  source-gen contexts (aspnetcore native AOT support)
+
+## Decision shortcut
+
+| Library uses                           | Replace with                                         |
+| -------------------------------------- | ---------------------------------------------------- |
+| Newtonsoft.Json / reflection S.T.J     | STJ source-gen context                               |
+| `[DllImport]`                          | `[LibraryImport]`                                    |
+| `new Regex(...)` with constant pattern | `[GeneratedRegex]`                                   |
+| `IConfiguration` → options binding     | `EnableConfigurationBindingGenerator`                |
+| Options DataAnnotations validation     | `[OptionsValidator]`                                 |
+| Dynamic IL emit for perf               | `IsDynamicCodeSupported` guard + fallback, or remove |

--- a/.agents/skills/dotnet-aot-library-validation/references/test-app-validation.md
+++ b/.agents/skills/dotnet-aot-library-validation/references/test-app-validation.md
@@ -1,0 +1,155 @@
+# Test-app validation
+
+Roslyn analyzers analyze one project at a time and cannot see dependency
+implementations — they are necessary but not complete. AOT-publishing a test
+app that references the library gives the compiler full visibility: it
+analyzes every method and type in the library and emits the complete warning
+set. Zero warnings = the library is verified AOT compatible.
+
+This is the pattern Microsoft ships and the OpenTelemetry .NET repo uses
+(`AotCompatibility.TestApp.csproj` + publish script + CI workflow).
+
+## 1. Test app project
+
+Create a sibling console project, e.g. `AotCompatibility.TestApp.csproj`:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\MyLibrary\MyLibrary.csproj" />
+    <TrimmerRootAssembly Include="MyLibrary" />
+  </ItemGroup>
+
+</Project>
+```
+
+Key points:
+
+- `PublishAot` in the project file (not the command line) — it controls
+  analysis during build/edit, not just publish.
+- `TrimmerRootAssembly` names the library assembly (file name without
+  extension). It roots _everything_ in the library, so the compiler treats it
+  as if all code is called — no member escapes analysis.
+- Use `TrimmerRootAssembly`, _not_ `PublishTrimmed` alone. (For the
+  trim-only variant of this pattern, swap `PublishAot` for
+  `PublishTrimmed`; everything else is identical.)
+- One app can root several libraries (all as `ProjectReference` +
+  `TrimmerRootAssembly`); isolating per library makes attribution clearer.
+- If the library uses `#if`-conditional behavior per TFM, add a test app per
+  relevant TFM.
+
+Add a `Program.cs` that exercises key library APIs when the app runs — this
+becomes the execution harness for suppressed warnings:
+
+```csharp
+using MyLibrary;
+
+// Exercise public surface; return non-zero on unexpected behavior.
+Console.WriteLine(Codec.Encode("sample"));
+```
+
+## 2. Publish and check
+
+```bash
+dotnet publish AotCompatibility.TestApp -c Release -r <RID>
+```
+
+- `<RID>`: use the host RID for a runnable binary (`osx-arm64`, `win-x64`,
+  `linux-x64`...). CI may cross-compile other RIDs for warning analysis only —
+  cross-compiled binaries cannot execute on the build host.
+- Native toolchain prerequisites: clang + zlib dev packages (Linux distros;
+  see Native AOT overview docs), Xcode Command Line Tools (macOS), VS 2022
+  "Desktop development with C++" workload (Windows).
+
+## 3. Publish script (fail on new warnings)
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$(uname -s)/$(uname -m)" in
+  Darwin/arm64)  RID=osx-arm64 ;;
+  Darwin/x86_64) RID=osx-x64 ;;
+  Linux/x86_64)  RID=linux-x64 ;;
+  Linux/aarch64) RID=linux-arm64 ;;
+  MINGW*/x86_64|CYGWIN*/x86_64) RID=win-x64 ;;
+  *) echo "Unsupported host: $(uname -s)/$(uname -m)"; exit 1 ;;
+esac
+
+LOG=$(mktemp)
+dotnet publish AotCompatibility.TestApp -c Release -r "$RID" > "$LOG" 2>&1 || { cat "$LOG"; exit 1; }
+
+# Trimming analysis warnings IL2xxx and AOT warnings IL3xxx indicate breaks.
+grep -E 'warning (IL2[0-9]{3}|IL3[0-9]{3})' "$LOG" | sort -u > warnings.txt
+
+if [ -s warnings.txt ]; then
+  echo "AOT compatibility warnings found:"
+  cat warnings.txt
+  exit 1
+fi
+
+echo "AOT compatibility: clean."
+./bin/Release/net8.0/$RID/publish/AotCompatibility.TestApp   # exercise APIs
+```
+
+Keep an allowlist if you deliberately suppress warnings: diff current warnings
+against the allowlist and fail on _new_ codes only — new warnings are treated
+as breaking changes for AOT consumers.
+
+## 4. GitHub Actions workflow
+
+```yaml
+name: aot-compatibility
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  aot:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      # Linux native toolchain
+      - run: sudo apt-get install -y clang zlib1g-dev
+        if: runner.os == 'Linux'
+      - run: ./build/test-aot-compatibility.sh
+```
+
+Reference implementation (OpenTelemetry .NET):
+
+- `test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj`
+- `build/test-aot-compatibility.ps1`
+- `.github/workflows/ci-aot.yml`
+
+## 5. Run the published binary when suppressions exist
+
+Suppressed warnings have no static safety net — the only proof is execution.
+The test app must call the code paths behind every suppression and assert
+correct behavior (the OpenTelemetry approach: app returns failure exit code if
+an API misbehaves). Without suppressions, running the app is still cheap
+insurance.
+
+## Common pitfalls
+
+- Rooting the _test app's_ assembly instead of the library — nothing useful
+  is analyzed; the library gets trimmed away entirely.
+- Analyzing only `net8.0` when conditional compilation changes behavior per
+  TFM.
+- Forgetting the toolchain install step in Linux CI — publish fails with
+  confusing linker errors.
+- Treating IL2104 ("assembly produced trim warnings") as ignorable — it is a
+  rollup of real site warnings in dependencies.

--- a/.agents/skills/dotnet-aot-library-validation/references/warning-catalog.md
+++ b/.agents/skills/dotnet-aot-library-validation/references/warning-catalog.md
@@ -1,0 +1,48 @@
+# Warning catalog
+
+Codes emitted by the trim/AOT/single-file Roslyn analyzers and by
+`dotnet publish` with `PublishAot` or `PublishTrimmed`. Trim-family docs:
+https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/
+AOT-family docs:
+https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/warnings/
+
+## Trim warnings (IL2xxx)
+
+| Code   | Meaning                                                                                              | Typical fix                                                                             |
+| ------ | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| IL2026 | Calling a member annotated `[RequiresUnreferencedCode]`                                              | Eliminate the call, propagate the annotation up to a public API, or use an alternative  |
+| IL2046 | Member annotated `[RequiresUnreferencedCode]` mismatch across override/interface                     | Align annotations on base/interface and implementations; avoid annotating virtuals      |
+| IL2065 | Value passed where `[DynamicallyAccessedMembers]` requirement not met (in attribute context)         | Annotate the flow source                                                                |
+| IL2067 | Parameter value does not satisfy the target's `[DynamicallyAccessedMembers]` requirement             | Add matching `[DynamicallyAccessedMembers]` to the parameter (or source field/property) |
+| IL2070 | `this` argument does not satisfy requirement in call to reflection method (e.g. `Type.GetMethods()`) | Annotate the receiving parameter; if the `Type` is statically known, drop reflection    |
+| IL2072 | Return value does not satisfy the target's requirement                                               | Annotate the return type or restructure so the source is statically known               |
+| IL2075 | Reflected member not statically known to exist (member not preserved)                                | Statically know the type or annotate the flow; do not suppress blindly                  |
+| IL2077 | Field value does not satisfy the target's requirement                                                | Add `[DynamicallyAccessedMembers]` to the field                                         |
+| IL2104 | `Assembly 'X' produced trim warnings` — dependency has un-actioned warnings                          | Fix or acknowledge dependency issues; verify with test app                              |
+| IL2125 | Referenced assembly lacks `IsTrimmable` metadata (only with `VerifyReferenceTrimCompatibility`)      | Dependency not annotated; opt-in check, noisy by design                                 |
+
+## AOT warnings (IL3xxx, RequiresDynamicCode family)
+
+| Code   | Meaning                                                                                             | Typical fix                                                                                                                             |
+| ------ | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| IL3050 | Calling a member annotated `[RequiresDynamicCode]` (e.g. `Type.MakeGenericType`, `Reflection.Emit`) | Restrict to statically known instantiations, guard with `RuntimeFeature.IsDynamicCodeSupported`, or mark caller `[RequiresDynamicCode]` |
+| IL3051 | `[RequiresDynamicCode]` mismatch between virtual/interface method and its override/implementation   | Make annotations consistent across base/interface and implementations                                                                   |
+| IL3058 | Referenced assembly lacks `IsAotCompatible` metadata (only with `VerifyReferenceAotCompatibility`)  | Dependency not annotated; metadata only written by .NET 10+ builds — expect noise on older packages                                     |
+
+## Assembly-level summary warnings
+
+| Code                                       | Meaning                                                                    |
+| ------------------------------------------ | -------------------------------------------------------------------------- |
+| IL2104                                     | Assembly produced trim warnings (dependency contains un-actioned warnings) |
+| IL2111 / IL2121 / IL2122 / IL2123 / IL2124 | Feature-level trim incompatibilities (framework assemblies)                |
+
+## Reading strategy
+
+1. Fix leaf codes first (`IL2026`–`IL2087` family): each is a concrete site.
+2. Assembly-level codes (`IL2104`) are rollups — they clear when the underlying
+   site warnings clear.
+3. The same pattern often produces several codes along one flow
+   (e.g. one un-annotated `Type` field can yield `IL2077` then `IL2067`).
+   Fixing the source (the field) clears the whole chain.
+4. Unknown code? Search the warning docs: `.../trimming/trim-warnings/<code>` or
+   `.../native-aot/warnings/<code>`.

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -35,7 +35,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6.0.0
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            11.0.x
 
       - name: Install Native AOT toolchain
         run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -26,6 +26,23 @@ jobs:
       # can fall below the gate (64% observed). Collecting on a single TFM with a
       # unique output per project keeps the report deterministic.
       enableCodeCoverage: false
+  aot-compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6.0.0
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Install Native AOT toolchain
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      - name: Validate AOT compatibility
+        run: ./scripts/test-aot-compatibility.sh
+
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It provides a configuration provider for [Microsoft.Extensions.Configuration](ht
 - ✅ Converted to use `System.Text.Json` only
 - ✅ Refactored structure for better modern SDK usage
 - ✅ Comprehensive logging, batch fetch, and polling/reload support
+- ✅ Official Native AOT support on `net8.0` and later
 - ✅ Published as a new NuGet package: [`AWSSecretsManager.Provider`](https://www.nuget.org/packages/AWSSecretsManager.Provider)
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ It is a modern, community-maintained fork of [Kralizek/AWSSecretsManagerConfigur
 - Fetches secrets from AWS Secrets Manager and exposes them as `IConfiguration` key/value pairs.
 - Flattens JSON-object/array secret values into hierarchical, `:`-delimited configuration keys — the same shape `appsettings.json` produces.
 - Supports filtering (by ARN allowlist, custom predicate, or AWS-side `ListSecrets` filters), custom key naming, custom AWS client construction, and optional background polling for live reload.
-- Works from `netstandard2.0` up through the latest .NET, in console apps, worker services, and ASP.NET Core.
+- Works from `netstandard2.0` up through the latest .NET, in console apps, worker services, and ASP.NET Core. Native AOT is officially supported for `net8.0` and later.
 
 ## What it doesn't do
 
@@ -21,16 +21,16 @@ It is a modern, community-maintained fork of [Kralizek/AWSSecretsManagerConfigur
 
 ## Where to go next
 
-| Page | Read this for... |
-|---|---|
-| [Getting Started](getting-started.md) | Installing the package and wiring up your first `AddSecretsManager()` call. |
-| [Configuration & Secret Mapping](configuration.md) | Every option on `SecretsManagerConfigurationProviderOptions`, and exactly how a secret value becomes one or more configuration keys. |
-| [Advanced Usage](advanced.md) | Batch fetching, polling/reload, `ForceReloadAsync`, and custom AWS client construction. |
-| [Authentication & Security](authentication-and-security.md) | Credential resolution, region resolution, required IAM permissions, and secret-exposure guidance. |
-| [Platform Support](platform-support.md) | Target framework compatibility and using the provider against LocalStack for local development. |
-| [Troubleshooting & FAQ](troubleshooting.md) | Diagnosing common failures and answers to recurring questions. |
-| [API Reference](api-reference.md) | Full signatures for every public type and member. |
-| [AI Coding Agent Skill](agent-skill.md) | An installable Agent Skill that teaches AI coding assistants to use this package correctly. |
+| Page                                                        | Read this for...                                                                                                                     |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| [Getting Started](getting-started.md)                       | Installing the package and wiring up your first `AddSecretsManager()` call.                                                          |
+| [Configuration & Secret Mapping](configuration.md)          | Every option on `SecretsManagerConfigurationProviderOptions`, and exactly how a secret value becomes one or more configuration keys. |
+| [Advanced Usage](advanced.md)                               | Batch fetching, polling/reload, `ForceReloadAsync`, and custom AWS client construction.                                              |
+| [Authentication & Security](authentication-and-security.md) | Credential resolution, region resolution, required IAM permissions, and secret-exposure guidance.                                    |
+| [Platform Support](platform-support.md)                     | Target framework compatibility and using the provider against LocalStack for local development.                                      |
+| [Troubleshooting & FAQ](troubleshooting.md)                 | Diagnosing common failures and answers to recurring questions.                                                                       |
+| [API Reference](api-reference.md)                           | Full signatures for every public type and member.                                                                                    |
+| [AI Coding Agent Skill](agent-skill.md)                     | An installable Agent Skill that teaches AI coding assistants to use this package correctly.                                          |
 
 ## Installation
 

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -2,15 +2,23 @@
 
 ## Target framework matrix
 
-| Target | Notes |
-|---|---|
+| Target           | Notes                                                                                                                   |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `netstandard2.0` | Enables consumption from .NET Framework 4.6.2+ and .NET Core 2.0+, alongside anything else that targets netstandard2.0. |
-| `net8.0` | Long-term-supported .NET release. |
-| `net9.0` | Current .NET release. |
-| `net10.0` | Current .NET release. |
-| `net11.0` | Forward-looking target, tracked as it becomes generally available. |
+| `net8.0`         | Long-term-supported .NET release.                                                                                       |
+| `net9.0`         | Current .NET release.                                                                                                   |
+| `net10.0`        | Current .NET release.                                                                                                   |
+| `net11.0`        | Forward-looking target, tracked as it becomes generally available.                                                      |
 
-`Microsoft.Extensions.Configuration` is version-pinned per target framework in this package (via central package management) so each build picks up the matching stable (or, for `net11.0`, current preview) line of that package rather than an incompatible cross-major version — this is an internal packaging detail and requires no action from consumers.
+`Microsoft.Extensions.Configuration` is version-pinned per target framework in this package (via central package management) so each build picks up the matching stable (or, for `net11.0`, current preview) line of that package rather than an incompatible cross-major version. Consumers need not configure this.
+
+## Native AOT
+
+`AWSSecretsManager.Provider` and `AWSSSM.Provider` officially support Native AOT in apps targeting `net8.0` or later. Both packages enable trim and AOT analyzers for those targets. CI publishes a Native AOT test app that roots every member in both assemblies and fails on trim (`IL2xxx`) or AOT (`IL3xxx`) warnings.
+
+JSON object and array values use `System.Text.Json` DOM APIs (`JsonDocument` and `JsonElement`). This path does not require reflection-based serialization or a source-generated serializer context.
+
+`netstandard2.0` remains supported for non-AOT consumers. Native AOT apps select a `net8.0` or later asset.
 
 ## Local development against LocalStack
 

--- a/scripts/test-aot-compatibility.sh
+++ b/scripts/test-aot-compatibility.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$(uname -s)/$(uname -m)" in
+  Darwin/arm64) RID=osx-arm64 ;;
+  Darwin/x86_64) RID=osx-x64 ;;
+  Linux/x86_64) RID=linux-x64 ;;
+  Linux/aarch64) RID=linux-arm64 ;;
+  MINGW*/x86_64|CYGWIN*/x86_64) RID=win-x64 ;;
+  *) echo "Unsupported host: $(uname -s)/$(uname -m)"; exit 1 ;;
+esac
+
+project=tests/AotCompatibility.TestApp/AotCompatibility.TestApp.csproj
+log=$(mktemp)
+trap 'rm -f "$log"' EXIT
+
+if ! dotnet publish "$project" -c Release -r "$RID" >"$log" 2>&1; then
+  cat "$log"
+  exit 1
+fi
+
+if grep -E 'warning IL(2|3)[0-9]{3}' "$log" | sort -u; then
+  echo "AOT compatibility warnings found."
+  exit 1
+fi
+
+"tests/AotCompatibility.TestApp/bin/Release/net8.0/$RID/publish/AotCompatibility.TestApp"
+echo "AOT compatibility: clean."

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "dotnet-aot-library-validation": {
+      "source": "LayeredCraft/skills",
+      "sourceType": "github",
+      "skillPath": "skills/dotnet-aot-library-validation/SKILL.md",
+      "computedHash": "b34a116d27d73b2675ec2e5dd2b1070e000453c402246409ae224961a58f8a8b"
+    }
+  }
+}

--- a/skills/aws-secrets-manager-provider/SKILL.md
+++ b/skills/aws-secrets-manager-provider/SKILL.md
@@ -4,7 +4,7 @@ description: Helps correctly integrate and configure the AWSSecretsManager.Provi
 license: MIT
 metadata:
   author: LayeredCraft
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 # AWSSecretsManager.Provider
@@ -17,7 +17,7 @@ metadata:
 dotnet add package AWSSecretsManager.Provider
 ```
 
-Supported: `netstandard2.0` (→ .NET Framework 4.6.2+, .NET Core 2.0+), `net8.0`, `net9.0`, `net10.0`, `net11.0`.
+Supported: `netstandard2.0` (→ .NET Framework 4.6.2+, .NET Core 2.0+), `net8.0`, `net9.0`, `net10.0`, `net11.0`. Native AOT is officially supported when an app targets `net8.0` or later. JSON secret flattening uses `System.Text.Json` DOM APIs and needs no source-generated serializer context.
 
 ## Core usage patterns
 

--- a/skills/aws-ssm-provider/SKILL.md
+++ b/skills/aws-ssm-provider/SKILL.md
@@ -4,7 +4,7 @@ description: Helps correctly integrate and configure the AWSSSM.Provider NuGet p
 license: MIT
 metadata:
   author: LayeredCraft
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 # AWSSSM.Provider
@@ -17,7 +17,7 @@ metadata:
 dotnet add package AWSSSM.Provider
 ```
 
-Supported: `netstandard2.0` (→ .NET Framework 4.6.2+), `net8.0`, `net9.0`, `net10.0`, `net11.0`.
+Supported: `netstandard2.0` (→ .NET Framework 4.6.2+), `net8.0`, `net9.0`, `net10.0`, `net11.0`. Native AOT is officially supported when an app targets `net8.0` or later. JSON parameter flattening uses `System.Text.Json` DOM APIs and needs no source-generated serializer context.
 
 ## Core usage patterns
 

--- a/src/AWSSSM.Provider/AWSSSM.Provider.csproj
+++ b/src/AWSSSM.Provider/AWSSSM.Provider.csproj
@@ -4,6 +4,7 @@
     <LangVersion>default</LangVersion>
 	<Nullable>enable</Nullable>
     <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
     <PackageId>AWSSSM.Provider</PackageId>
     <Title>AWSSSM.Provider</Title>
     <Description>An AWS SSM Parameter Store-backed configuration provider for .NET applications using Microsoft.Extensions.Configuration.</Description>

--- a/src/AWSSSM.Provider/README.md
+++ b/src/AWSSSM.Provider/README.md
@@ -12,6 +12,7 @@ It loads parameters under a hierarchy path from [AWS SSM Parameter Store](https:
 ## ✨ Features
 
 - ✅ Targeted to .NET 8, 9, 10, and 11 (plus `netstandard2.0`)
+- ✅ Official Native AOT support on `net8.0` and later
 - ✅ Hierarchical parameter loading via `GetParametersByPath` (recursive by default)
 - ✅ Automatic JSON flattening of `String` and `SecureString` parameter values
 - ✅ Optional background polling for parameter changes

--- a/src/AWSSecretsManager.Provider/AWSSecretsManager.Provider.csproj
+++ b/src/AWSSecretsManager.Provider/AWSSecretsManager.Provider.csproj
@@ -4,6 +4,7 @@
     <LangVersion>default</LangVersion>
 	<Nullable>enable</Nullable>  
     <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
     <PackageId>AWSSecretsManager.Provider</PackageId>
     <Title>AWSSecretsManager.Provider</Title>
     <Description>An AWS Secrets Manager-backed configuration provider for .NET applications using Microsoft.Extensions.Configuration.</Description>

--- a/tests/AotCompatibility.TestApp/AotCompatibility.TestApp.csproj
+++ b/tests/AotCompatibility.TestApp/AotCompatibility.TestApp.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/AWSSecretsManager.Provider/AWSSecretsManager.Provider.csproj" />
+    <ProjectReference Include="../../src/AWSSSM.Provider/AWSSSM.Provider.csproj" />
+    <TrimmerRootAssembly Include="AWSSecretsManager.Provider" />
+    <TrimmerRootAssembly Include="AWSSSM.Provider" />
+  </ItemGroup>
+
+</Project>

--- a/tests/AotCompatibility.TestApp/Program.cs
+++ b/tests/AotCompatibility.TestApp/Program.cs
@@ -1,0 +1,15 @@
+using AWSSecretsManager.Provider;
+using AWSSSM.Provider;
+using Microsoft.Extensions.Configuration;
+
+var configurationBuilder = new ConfigurationBuilder();
+configurationBuilder
+    .AddSecretsManager()
+    .AddSsmParameters();
+
+if (configurationBuilder.Sources.Count != 2)
+{
+    return 1;
+}
+
+return 0;

--- a/tests/AotCompatibility.TestApp/Program.cs
+++ b/tests/AotCompatibility.TestApp/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using AWSSecretsManager.Provider;
 using AWSSSM.Provider;
 using Microsoft.Extensions.Configuration;
@@ -9,6 +10,7 @@ configurationBuilder
 
 if (configurationBuilder.Sources.Count != 2)
 {
+    Console.WriteLine($"AOT compatibility failure: expected 2 configuration sources but found {configurationBuilder.Sources.Count}.");
     return 1;
 }
 


### PR DESCRIPTION
## Summary

Add official Native AOT support for both configuration providers. Package builds enable AOT analyzers on `net8.0+`, while CI publishes a rooted Native AOT app and rejects trim or AOT warnings.

## Changes

- Enable `IsAotCompatible` for `AWSSecretsManager.Provider` and `AWSSSM.Provider` on `net8.0+`.
- Add rooted AOT validation app and Linux CI job.
- Document AOT support and JSON DOM behavior in package docs and agent skills.
- Add `AGENTS.md` symlink to `CLAUDE.md`.

## Validation

- `./scripts/test-aot-compatibility.sh`
- `dotnet build AWSSecretsManager.slnx -c Release --no-restore`
- `uv run mkdocs build --strict`
